### PR TITLE
When sending from my server which already had an SSL certificate

### DIFF
--- a/libraries/Amazon_ses.php
+++ b/libraries/Amazon_ses.php
@@ -451,7 +451,10 @@ class Amazon_ses
 		$this->_set_headers();
 		
 		// Make sure we connect over HTTPS and verify
-		$this->_ci->curl->ssl(TRUE, 2, $this->_cert_path);
+		if( ! isset($_SERVER['HTTPS']))
+		{
+			$this->_ci->curl->ssl(TRUE, 2, $this->_cert_path);
+		}
 		
 		// Show headers when in debug mode		
 		if($this->debug === TRUE)


### PR DESCRIPTION
When sending from my server which already had an SSL certificate installed, the certificate included in the curl conflicted and caused an error. Excluding it in this way fixed my issue and hopefully this patch will save someone else a headache.
