### PR TITLE
cURL loading fix

### DIFF
--- a/libraries/Amazon_ses.php
+++ b/libraries/Amazon_ses.php
@@ -69,13 +69,10 @@ class Amazon_ses {
 		// Load Phil's cURL library as a Spark or the normal way
 		if (method_exists($this->_ci->load, 'spark'))
 		{
-        	$this->_ci->load->spark('curl/1.0');
+        	$this->_ci->load->spark('curl/1.0.0');
 		}
-		else
-		{
-			$this->_ci->load->library('curl');		
-		}
-		
+        
+	    $this->_ci->load->library('curl');
 	}
 	
 	/**


### PR DESCRIPTION
A quick fix to the loading of the cURL spark
1. Fixed the version # to 1.0.0 (standard since May)
2. Since the curl spark doesn't autoload its lib, the logic is better off loading the spark if sparks exists, and then loading the curl lib regardless (CI won't load it twice)
